### PR TITLE
Add minimal GPT implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# PersonalNanoGPT
+
+PersonalNanoGPT is a compact implementation of a Transformer-based language model built with PyTorch. The project aims to provide a minimal yet functional codebase for experimentation and learning purposes.
+
+## Features
+
+- **Minimal GPT architecture** in `model.py` implemented with multi-head self-attention and feed-forward blocks.
+- **Training script** `train.py` that tokenizes raw text and optimizes the model using AdamW.
+- **Configurable parameters** including batch size, block size (context length), and number of training epochs.
+
+## Requirements
+
+- Python 3.8+
+- PyTorch 2.0 or later
+
+Install dependencies via pip:
+
+```bash
+pip install torch
+```
+
+## Usage
+
+Prepare a plain text file to use as training data. Then run the training script:
+
+```bash
+python train.py --text path/to/data.txt --epochs 5 --batch-size 64 --block-size 128 --output gpt.pth
+```
+
+This command trains the model on `data.txt` for five epochs and saves the resulting weights to `gpt.pth`. If a GPU is available, the script will use it automatically.
+
+## Repository Structure
+
+- `model.py` – Defines the GPT model architecture.
+- `train.py` – Provides a simple training loop for text data.
+- `LICENSE` – MIT license information.
+
+## License
+
+This project is released under the MIT License. See `LICENSE` for details.

--- a/model.py
+++ b/model.py
@@ -1,0 +1,85 @@
+import torch
+import torch.nn as nn
+import math
+
+class SelfAttention(nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int):
+        super().__init__()
+        assert embed_dim % num_heads == 0, "embed_dim must be divisible by num_heads"
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.query = nn.Linear(embed_dim, embed_dim)
+        self.key = nn.Linear(embed_dim, embed_dim)
+        self.value = nn.Linear(embed_dim, embed_dim)
+        self.proj = nn.Linear(embed_dim, embed_dim)
+
+    def forward(self, x: torch.Tensor):
+        B, T, C = x.size()
+        q = self.query(x).view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.key(x).view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+        v = self.value(x).view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+        att = (q @ k.transpose(-2, -1)) / math.sqrt(self.head_dim)
+        att = torch.softmax(att, dim=-1)
+        y = att @ v
+        y = y.transpose(1, 2).contiguous().view(B, T, C)
+        return self.proj(y)
+
+class FeedForward(nn.Module):
+    def __init__(self, embed_dim: int, hidden_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(embed_dim, hidden_dim)
+        self.gelu = nn.GELU()
+        self.fc2 = nn.Linear(hidden_dim, embed_dim)
+
+    def forward(self, x: torch.Tensor):
+        return self.fc2(self.gelu(self.fc1(x)))
+
+class TransformerBlock(nn.Module):
+    def __init__(self, embed_dim: int, num_heads: int, hidden_dim: int):
+        super().__init__()
+        self.ln1 = nn.LayerNorm(embed_dim)
+        self.attn = SelfAttention(embed_dim, num_heads)
+        self.ln2 = nn.LayerNorm(embed_dim)
+        self.ff = FeedForward(embed_dim, hidden_dim)
+
+    def forward(self, x: torch.Tensor):
+        x = x + self.attn(self.ln1(x))
+        x = x + self.ff(self.ln2(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, embed_dim: int = 256, num_heads: int = 8,
+                 num_layers: int = 4, hidden_dim: int = 512, block_size: int = 128):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.token_emb = nn.Embedding(vocab_size, embed_dim)
+        self.pos_emb = nn.Embedding(block_size, embed_dim)
+        self.blocks = nn.ModuleList([
+            TransformerBlock(embed_dim, num_heads, hidden_dim)
+            for _ in range(num_layers)
+        ])
+        self.ln_f = nn.LayerNorm(embed_dim)
+        self.head = nn.Linear(embed_dim, vocab_size, bias=False)
+        self.block_size = block_size
+        self.apply(self._init_weights)
+
+    def _init_weights(self, module: nn.Module):
+        if isinstance(module, nn.Linear):
+            nn.init.normal_(module.weight, mean=0.0, std=0.02)
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            nn.init.normal_(module.weight, mean=0.0, std=0.02)
+
+    def forward(self, idx: torch.Tensor):
+        B, T = idx.size()
+        assert T <= self.block_size, "Sequence length exceeds block size"
+        pos = torch.arange(0, T, device=idx.device).unsqueeze(0)
+        tok_emb = self.token_emb(idx)
+        pos_emb = self.pos_emb(pos)
+        x = tok_emb + pos_emb
+        for block in self.blocks:
+            x = block(x)
+        x = self.ln_f(x)
+        logits = self.head(x)
+        return logits

--- a/train.py
+++ b/train.py
@@ -1,0 +1,69 @@
+import argparse
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import Dataset, DataLoader
+
+from model import GPT
+
+class TextDataset(Dataset):
+    def __init__(self, path: Path, block_size: int = 128):
+        data = path.read_text(encoding='utf-8')
+        chars = sorted(set(data))
+        self.stoi = {ch: i for i, ch in enumerate(chars)}
+        self.itos = {i: ch for ch, i in self.stoi.items()}
+        self.vocab_size = len(chars)
+        self.block_size = block_size
+        encoded = [self.stoi[ch] for ch in data]
+        self.data = torch.tensor(encoded, dtype=torch.long)
+
+    def __len__(self):
+        return len(self.data) - self.block_size
+
+    def __getitem__(self, idx):
+        chunk = self.data[idx: idx + self.block_size + 1]
+        return chunk[:-1], chunk[1:]
+
+
+def train(args):
+    text_path = Path(args.text)
+    ds = TextDataset(text_path, block_size=args.block_size)
+    loader = DataLoader(ds, batch_size=args.batch_size, shuffle=True)
+
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = GPT(ds.vocab_size, block_size=args.block_size).to(device)
+    optim = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+    for epoch in range(args.epochs):
+        for x, y in loader:
+            x, y = x.to(device), y.to(device)
+            logits = model(x)
+            loss = F.cross_entropy(logits.view(-1, ds.vocab_size), y.view(-1))
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+        print(f"Epoch {epoch+1}: loss {loss.item():.4f}")
+
+    if args.output:
+        torch.save(model.state_dict(), args.output)
+
+
+def main():
+    p = argparse.ArgumentParser(description='Train a minimal GPT model')
+    p.add_argument('--text', type=str, required=True,
+                   help='Path to training text file')
+    p.add_argument('--epochs', type=int, default=1,
+                   help='Number of training epochs')
+    p.add_argument('--batch-size', type=int, default=64,
+                   help='Training batch size')
+    p.add_argument('--block-size', type=int, default=128,
+                   help='Context size for the model')
+    p.add_argument('--output', type=str,
+                   help='Optional path to save trained model')
+    args = p.parse_args()
+    train(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement a compact GPT model in `model.py`
- add training loop that tokenizes text and trains the model
- rewrite the README with setup and usage instructions

## Testing
- `python -m py_compile model.py train.py`
- `pip install torch` *(fails: ModuleNotFoundError due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684893bee3d48330b6f25e9314982329