### PR TITLE
Add personalized knowledge discovery framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ python advanced.py \
   --output gpt_offline.pth
 ```
 
+### Knowledge Discovery Training
+
+`explore.py` provides a lightweight interface for personalised data exploration
+on structured (`.csv`), semi-structured (`.jsonl`) and unstructured (`.txt`)
+datasets.
+
+```bash
+python explore.py \
+  --data path/to/data.csv \
+  --epochs 2 \
+  --output gpt_knowledge.pth
+```
+
 3. Generate text after training:
 
 ```python

--- a/explore.py
+++ b/explore.py
@@ -1,0 +1,93 @@
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Iterable
+
+import torch
+from torch.utils.data import Dataset, DataLoader
+import torch.nn.functional as F
+
+from model import GPT
+
+class KnowledgeDataset(Dataset):
+    """Load text from txt, csv, or json/jsonl files for GPT training."""
+    def __init__(self, path: Path, block_size: int = 128):
+        data = self._read_file(path)
+        chars = sorted(set(data))
+        self.stoi = {ch: i for i, ch in enumerate(chars)}
+        self.itos = {i: ch for ch, i in self.stoi.items()}
+        self.vocab_size = len(chars)
+        self.block_size = block_size
+        encoded = [self.stoi[ch] for ch in data]
+        self.data = torch.tensor(encoded, dtype=torch.long)
+
+    def _read_file(self, path: Path) -> str:
+        if path.suffix.lower() == '.txt':
+            return path.read_text(encoding='utf-8')
+        if path.suffix.lower() == '.csv':
+            rows = []
+            with path.open(newline='', encoding='utf-8') as f:
+                for row in csv.reader(f):
+                    rows.append(' '.join(row))
+            return '\n'.join(rows)
+        if path.suffix.lower() in {'.json', '.jsonl'}:
+            lines = []
+            with path.open(encoding='utf-8') as f:
+                for line in f:
+                    obj = json.loads(line)
+                    lines.append(' '.join(map(str, self._flatten(obj))))
+            return '\n'.join(lines)
+        raise ValueError(f"Unsupported file type: {path.suffix}")
+
+    def _flatten(self, obj):
+        if isinstance(obj, dict):
+            for v in obj.values():
+                yield from self._flatten(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                yield from self._flatten(item)
+        else:
+            yield obj
+
+    def __len__(self):
+        return len(self.data) - self.block_size
+
+    def __getitem__(self, idx):
+        chunk = self.data[idx: idx + self.block_size + 1]
+        return chunk[:-1], chunk[1:]
+
+
+def train_knowledge(args: argparse.Namespace):
+    ds = KnowledgeDataset(Path(args.data), block_size=args.block_size)
+    loader = DataLoader(ds, batch_size=args.batch_size, shuffle=True)
+
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = GPT(ds.vocab_size, block_size=args.block_size).to(device)
+    optim = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+    for epoch in range(args.epochs):
+        for x, y in loader:
+            x, y = x.to(device), y.to(device)
+            logits = model(x)
+            loss = F.cross_entropy(logits.view(-1, ds.vocab_size), y.view(-1))
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+        print(f"Epoch {epoch+1}: loss {loss.item():.4f}")
+
+    if args.output:
+        torch.save(model.state_dict(), args.output)
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(description='Knowledge Discovery Training')
+    p.add_argument('--data', type=str, required=True,
+                   help='Path to txt/csv/json data file')
+    p.add_argument('--epochs', type=int, default=1)
+    p.add_argument('--batch-size', type=int, default=64)
+    p.add_argument('--block-size', type=int, default=128)
+    p.add_argument('--output', type=str,
+                   help='Optional path to save trained model')
+    args = p.parse_args()
+    train_knowledge(args)

--- a/tests/data/sample.csv
+++ b/tests/data/sample.csv
@@ -1,0 +1,3 @@
+name,age,score
+alice,30,0.8
+bob,25,0.9

--- a/tests/data/sample.jsonl
+++ b/tests/data/sample.jsonl
@@ -1,0 +1,2 @@
+{"text": "hello", "label": 1}
+{"text": "world", "label": 0}

--- a/tests/data/sample.txt
+++ b/tests/data/sample.txt
@@ -1,0 +1,1 @@
+this is unstructured text data

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import torch
+from explore import KnowledgeDataset
+from model import GPT
+from advanced import char_reward_fn
+
+
+def run_case(filename, reward_chars):
+    path = Path('tests/data') / filename
+    ds = KnowledgeDataset(path, block_size=8)
+    model = GPT(ds.vocab_size, block_size=8)
+    if ds.vocab_size == 0:
+        return
+    reward_fn = char_reward_fn(reward_chars, ds.stoi)
+    first_token = next(iter(ds.stoi.values()))
+    idx = torch.tensor([[first_token]], dtype=torch.long)
+    out = model.generate_reward_augmented(idx, max_new_tokens=2,
+                                          reward_fn=reward_fn, beta=0.5)
+    assert out.shape[1] == 3
+
+
+def test_knowledge_dataset_variants():
+    scenarios = [
+        ('sample.txt', ['t']),
+        ('sample.txt', []),
+        ('sample.csv', ['a']),
+        ('sample.csv', ['1']),
+        ('sample.csv', []),
+        ('sample.jsonl', ['h']),
+        ('sample.jsonl', ['0']),
+        ('sample.jsonl', []),
+        ('sample.txt', ['u']),
+        ('sample.csv', ['s']),
+    ]
+    for fname, chars in scenarios:
+        run_case(fname, chars)


### PR DESCRIPTION
## Summary
- enable training on txt, csv and json data via new `KnowledgeDataset`
- provide `explore.py` CLI for knowledge discovery
- document the new workflow in README
- add test cases covering all data modalities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bb6a78e908330b7efdfc352a34aeb